### PR TITLE
Add papers on RLHF system, TVM and MQA

### DIFF
--- a/docs/data/software/algorithm.csv
+++ b/docs/data/software/algorithm.csv
@@ -12,6 +12,7 @@ Year,Venue,Authors,Title,Tags,P,E,N
 
 # ##### LLM Transformer
 # Solution: Transformer is an old algorithm, which have many problems like square complexity. These problems raise new algorithms to fix the old architecture.
+2019,arXiv,Google,Fast Transformer Decoding: One Write-Head is All You Need,MQA; share same KV cache for all heads; multi-query attention,1,4,3
 2024,NeuroComputing,ZhuiYi,RoFormer: Enhanced Transformer with Rotary Position Embedding,use rotary position embedding to fix the problem of long context; nter-word dependencies decay gradually with the increase of relative distance,3,4,3
 2025,arXiv,Qwen,Parallel Scaling Law for Language Models,enhance model's parallel ability to enhance the performance instead of increasing the model size; parallel multi output and conclude one output,4,4,4
 

--- a/docs/data/software/algorithm.csv
+++ b/docs/data/software/algorithm.csv
@@ -8,7 +8,7 @@ Year,Venue,Authors,Title,Tags,P,E,N
 
 # #### LLM Algorithm
 # Solution: enable ai chat with human, some people think is the way to AGI.
-2020,arXiv,Scaling Laws for Neural Language Models,fundamentals of LLM; increase model size and performance raise,4,5,5
+2020,arXiv,OpenAI,Scaling Laws for Neural Language Models,fundamentals of LLM; increase model size and performance raise,4,5,5
 
 # ##### LLM Transformer
 # Solution: Transformer is an old algorithm, which have many problems like square complexity. These problems raise new algorithms to fix the old architecture.

--- a/docs/data/software/ds.csv
+++ b/docs/data/software/ds.csv
@@ -393,6 +393,11 @@ Year,Venue,Authors,Title,Tags,P,E,N
 2025,arXiv,UIUC,Hierarchical Autoscaling for Large Language Model Serving with Chiron,hierarchical backpressure; interactive requests and batch requests; mixed instances,,,
 2025,arXiv,Berkeley,Locality-aware Fair Scheduling in LLM Serving,deficit-based longest prefix matching; distributed deficit-round coordination; prefix-aware fairness bound analysis,,,
 
+# ### RLHF System
+# Challenge: RLHF system includes both training and inference. On top of that, multi agents(LLMs) when running in parallel, which makes the data flow more complex.
+2025,EuroSys,HKU,HybridFlow: A Flexible and Efficient RLHF Framework,auto-mapping model placement; 3D-HybridEngine to reduce the communication overhead; hybrid programming,4,4,3
+
+
 # ### Communication-Computation Overlap
 # Challenge: effectively hiding communication latency by overlapping it with computation, which requires careful scheduling and resource management to avoid bottlenecks and ensure that both communication and computation proceed efficiently without stalling each other.
 2023,NSDI,KAIST,ARK: GPU-driven Code Execution for Distributed Deep Learning,communication-motivated DL system; pipeline DMA engine; GPU-direct-controlled DMA,,,

--- a/docs/data/software/pl.csv
+++ b/docs/data/software/pl.csv
@@ -8,7 +8,7 @@ Year,Venue,Authors,Title,Tags,P,E,N
 
 # ### Deep Learning Compilers
 # Solution: Graph transformations, Kernel fusion, Tensor optimization for compute and memory
-2018,OSDI,TVM,TVM: An Automated End-to-End Optimizing Compiler for Deep Learning,operator fusion; graph-level DL compiler; automatic code generation; tensor expression simplification,4,4,4
+2018,OSDI,UW,TVM: An Automated End-to-End Optimizing Compiler for Deep Learning,operator fusion; graph-level DL compiler; automatic code generation; tensor expression simplification,4,4,4
 2025,PPoPP,Thu,FlashTensor: Optimizing Tensor Programs by Leveraging Fine-grained Tensor Property,dataflow centered code recognition and optimization; two-stage heuristic algorithm to optimize tensor computation; kernel fusion,4,4,2
 
 # ### Domain-Specific Languages

--- a/docs/data/software/pl.csv
+++ b/docs/data/software/pl.csv
@@ -8,6 +8,7 @@ Year,Venue,Authors,Title,Tags,P,E,N
 
 # ### Deep Learning Compilers
 # Solution: Graph transformations, Kernel fusion, Tensor optimization for compute and memory
+2018,OSDI,TVM,TVM: An Automated End-to-End Optimizing Compiler for Deep Learning,operator fusion; graph-level DL compiler; automatic code generation; tensor expression simplification,4,4,4
 2025,PPoPP,Thu,FlashTensor: Optimizing Tensor Programs by Leveraging Fine-grained Tensor Property,dataflow centered code recognition and optimization; two-stage heuristic algorithm to optimize tensor computation; kernel fusion,4,4,2
 
 # ### Domain-Specific Languages


### PR DESCRIPTION
# Paper description

This week's time is mainly spent on mt final exam, so I carefully studied three classic papers.

- RLHF: RLHF system is different from both inference and trainning. It's dataflow is more complex
- TVM: most classic of DL compiler
- MQA: old work on share KVC between attn-head

Also fix a typo on last week's papers.

# Contributing to LEMONADE reviews

Please review the project guidelines and check the boxes below.

**Subsections:**

- [x] Place papers only in **Level 3** or **Level 4** subsections.
- [x] Each subsection state the **common challenge**.
- [x] Each subsection has **at least 2 papers**.
- [x] Each subsection has **no more than 5 papers**.

**Tags:**

- [x] Tags are **specific techniques or contributions**
- [x] **No** broad area tags (like "performance") were used.
- [x] **No** vague feature tags (like "efficiency") were used *alone*.
- [x] Any potentially unclear acronyms in tags are **explained**.
