### PR TITLE
Add papers on LLM-centered scene

### DIFF
--- a/docs/data/software/ds.csv
+++ b/docs/data/software/ds.csv
@@ -68,6 +68,7 @@ Year,Venue,Authors,Title,Tags,P,E,N
 # Challenge: LLM memory management faces challenges like limited HBM memory, efficient KV Cache management, memory sharing between multiple GPUs, multi-level memory management.
 2025,arXiv,THU,Jenga: Effective Memory Management for Serving LLM with Heterogeneity,fixed-size embeddings; full-prefix dependency; two-level memory allocator,4,4,3
 2025,FAST,THU,Mooncake: Trading More Storage for Less Computation — A KVCache-centric Architecture for Serving LLM Chatbot,PD-disaggregate system; kv-cache centered; global kv-cache pool; dynamic SLO scheduler; paged KV-Cache storage,3,4,2
+2022,SC,Miscrosoft,DeepSpeed- Inference: Enabling Efficient Inference of Transformer Models at Unprecedented Scale,kernel fusion; GPU-CPU-NVMe heterogeneous memory; PCIe-based memory prefetch,4,4,3
 
 # #### KV Cache Reuse Systems
 # Solution: reduce redundant computation and high memory consumption during inference by allowing the reuse of previously computed key-value pairs for shared or repeated parts of input sequences.

--- a/docs/data/software/ds.csv
+++ b/docs/data/software/ds.csv
@@ -61,6 +61,7 @@ Year,Venue,Authors,Title,Tags,P,E,N
 # #### Memory Management Algorithms
 # Solution: efficient memory management algorithms, like virtual memory, page table, etc.
 2023,SOSP,UCB,Efficient Memory Management for Large Language Model Serving with PagedAttention,Paged KV-Cache management; Better memory management for larger batch size; Preemptive memory scheduling,4,5,3
+2025,ASPLOS,Miscrosoft,vAttention: Dynamic Memory Management for Serving LLMs without PagedAttention,use cuda hardware page table instead of vllm's; hack cuda's driver to support page table modify,2,3,3
 2022,NIPS,Stanford,FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness,Generalized Acceleration of Attention Mechanisms; Change attention to utilize the SRAM on GPU; use recompute to reduce IO burden,4,5,4
 
 # #### General LLM Memory Management

--- a/docs/data/software/pl.csv
+++ b/docs/data/software/pl.csv
@@ -8,6 +8,7 @@ Year,Venue,Authors,Title,Tags,P,E,N
 
 # ### Deep Learning Compilers
 # Solution: Graph transformations, Kernel fusion, Tensor optimization for compute and memory
+2013,PLDI,MIT,Halide: A Language and Compiler for Optimizing Parallelism Locality and Recomputation in Image Processing Pipelines,image process DSL; Compute and Schedule Separation IR Design Idea; Pipeline optimization,4,4,3
 2018,OSDI,UW,TVM: An Automated End-to-End Optimizing Compiler for Deep Learning,operator fusion; graph-level DL compiler; automatic code generation; tensor expression simplification,4,4,4
 2025,PPoPP,Thu,FlashTensor: Optimizing Tensor Programs by Leveraging Fine-grained Tensor Property,dataflow centered code recognition and optimization; two-stage heuristic algorithm to optimize tensor computation; kernel fusion,4,4,2
 


### PR DESCRIPTION
# Intro

The papers are from these topics:

1. Halide: the base of the initial version of TVM. Recently I researched TVM and read related papers.
2. vAttn: use physical page table instead of vllm's software implementation.
3. DeepSpeed: classic paper for LLM inference

# Contributing to LEMONADE reviews

Please review the project guidelines and check the boxes below.

**Subsections:**

- [x] Place papers only in **Level 3** or **Level 4** subsections.
- [x] Each subsection state the **common challenge**.
- [x] Each subsection has **at least 2 papers**.
- [x] Each subsection has **no more than 5 papers**.

**Tags:**

- [x] Tags are **specific techniques or contributions**
- [x] **No** broad area tags (like "performance") were used.
- [x] **No** vague feature tags (like "efficiency") were used *alone*.
- [x] Any potentially unclear acronyms in tags are **explained**.
